### PR TITLE
feat: Optimize application for 512MB memory limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,46 @@
-# Use Python slim image
-FROM python:3.10-slim
+# Builder Stage
+FROM python:3.10-slim as builder
 
-# Set environment variables
-ENV PYTHONUNBUFFERED=1
-
-# Set up working directory
+# Set working directory
 WORKDIR /app
 
-# Install system dependencies
+# Install necessary build tools
 RUN apt-get update && apt-get install -y \
     build-essential \
     curl \
-    git \
+    python3-dev \
+    --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy requirements first to leverage Docker cache
-COPY requirements.txt .
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Create a virtual environment
+RUN python3 -m venv /opt/venv
 
-# Create model directory
-RUN mkdir -p /app/models
+# Copy requirements.txt and install Python dependencies into the virtual environment
+COPY requirements.txt .
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
 # Download the TinyLlama model
-RUN curl -L https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf -o /app/models/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf
+RUN mkdir -p /app/models && \
+    curl -L https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q2_K.gguf -o /app/models/tinyllama-1.1b-chat-v1.0.Q2_K.gguf
+
+# Final Stage
+FROM python:3.10-slim
+
+# Set working directory
+WORKDIR /app
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy the virtual environment from the builder stage
+COPY --from=builder /opt/venv /opt/venv
+
+# Copy the downloaded model from the builder stage
+COPY --from=builder /app/models /app/models
 
 # Copy application code
 COPY . .
 
 # Run the application
-CMD uvicorn frontend.app:app --host 0.0.0.0 --port $PORT 
+CMD ["uvicorn", "frontend.app:app", "--host", "0.0.0.0", "--port", "$PORT"]

--- a/backend/chat_backend.py
+++ b/backend/chat_backend.py
@@ -29,11 +29,11 @@ def initialize_models():
         # Initialize TinyLlama
         llm = AutoModelForCausalLM.from_pretrained(
             "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-            model_file="tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
+            model_file="tinyllama-1.1b-chat-v1.0.Q2_K.gguf",
             model_type="llama",
             gpu_layers=0,  # CPU only for Render free tier
-            context_length=2048,  # Set a reasonable context length
-            threads=4  # Limit threads to stay within Render's free tier
+            context_length=1024,  # Set a reasonable context length
+            threads=2  # Limit threads to stay within Render's free tier
         )
         
         # Initialize sentence transformer for embeddings

--- a/render.yaml
+++ b/render.yaml
@@ -10,5 +10,5 @@ services:
     plan: free
     resources:
       cpu: 2
-      memory: 4GB
+      memory: 512MB
       disk: 10GB

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 fastapi==0.104.0
 uvicorn==0.24.0
-streamlit==1.28.0
 pandas==2.1.4
 openpyxl==3.1.2
 langchain-core>=0.1.4


### PR DESCRIPTION
This commit introduces several changes to reduce the memory footprint of the application, aiming to allow deployment on Render's free tier with a 512MB RAM limit.

Key changes include:

1.  **render.yaml**: Updated memory allocation to 512MB.
2.  **LLM Update**: Switched from the Q4_K_M (637MB) to the Q2_K (488MB) quantization of TinyLlama-1.1B-Chat-v1.0. This significantly reduces the model size. Both Dockerfile and chat_backend.py were updated.
3.  **Dockerfile Optimization**: Implemented a multi-stage build to exclude build-time dependencies like build-essential from the final image. Removed git.
4.  **Dependency Pruning**: Removed the unused 'streamlit' library from requirements.txt.
5.  **LLM Parameter Tuning**: Reduced 'context_length' from 2048 to 1024 and 'threads' from 4 to 2 in the LLM configuration to decrease runtime memory usage.

These changes collectively aim to lower the application's memory requirements. Further testing in the target environment is recommended to confirm compatibility with the 512MB limit.