### PR TITLE
feat: Integrate AMD-Llama-135M-GGUF model

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ RUN python3 -m venv /opt/venv
 COPY requirements.txt .
 RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
-# Download the TinyLlama model
+# Download the AMD-Llama model
 RUN mkdir -p /app/models && \
-    curl -L https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q2_K.gguf -o /app/models/tinyllama-1.1b-chat-v1.0.Q2_K.gguf
+    curl -L https://huggingface.co/QuantFactory/AMD-Llama-135m-GGUF/resolve/main/Llama-135M-q4_0-main.gguf -o /app/models/Llama-135M-q4_0-main.gguf
 
 # Final Stage
 FROM python:3.10-slim

--- a/backend/chat_backend.py
+++ b/backend/chat_backend.py
@@ -27,10 +27,10 @@ logger = logging.getLogger(__name__)
 def initialize_models():
     """Initialize the LLM and embedding models."""
     try:
-        # Initialize TinyLlama
+        # Initialize AMD-Llama
         llm = AutoModelForCausalLM.from_pretrained(
-            "TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF",
-            model_file="tinyllama-1.1b-chat-v1.0.Q2_K.gguf",
+            "QuantFactory/AMD-Llama-135m-GGUF",
+            model_file="Llama-135M-q4_0-main.gguf",
             model_type="llama",
             gpu_layers=0,  # CPU only for Render free tier
             context_length=512,  # Set a reasonable context length
@@ -55,7 +55,7 @@ except Exception as e:
     raise
 
 def generate_text(prompt):
-    """Generate text using TinyLlama."""
+    """Generate text using AMD-Llama."""
     try:
         # Format the prompt properly for chat
         formatted_prompt = f"<|system|>\nYou are a helpful assistant focused on analyzing Excel data and generating insights. Stick strictly to the provided context.\n<|user|>\n{prompt}\n<|assistant|>\n"


### PR DESCRIPTION
Replaces the previous TinyLlama model with QuantFactory/AMD-Llama-135m-GGUF (Llama-135M-q4_0-main.gguf, 200MB) to significantly reduce memory footprint.

Changes include:
- Updated Dockerfile to download the new model.
- Updated chat_backend.py to use the new model file and repository ID.
- Kept LLM parameters (context_length=512, threads=1) conservative.

This change aims to resolve OOM errors on memory-constrained environments like Render's 512MB free tier.